### PR TITLE
style: monospace font-family for codes

### DIFF
--- a/resources/views/convert/base64.blade.php
+++ b/resources/views/convert/base64.blade.php
@@ -13,7 +13,9 @@
 </div>
 <form>
 	<div class="form-group">
-		<textarea id="query" class="form-control" rows="10" spellcheck="false">{{{$query ?: "请输入要编码或解码的字符串"}}}</textarea>
+		<samp>
+			<textarea id="query" class="form-control" rows="10" spellcheck="false">{{{$query ?: "请输入要编码或解码的字符串"}}}</textarea>
+		</samp>
 	</div>
 	<div class="form-group">
 		<div class="form-inline">

--- a/resources/views/encrypt/hash.blade.php
+++ b/resources/views/encrypt/hash.blade.php
@@ -22,7 +22,7 @@
 			<button type="submit" class="btn btn-primary">计算</button>
 		</div>
 	</form>
-	
+
 	<div class="col-xs-12">
 		<table class="table table-bordered table-striped mt10" style="word-break:break-word;">
 			<thead>
@@ -39,13 +39,15 @@
 				@foreach ($algos as $key => $algo)
 				<tr id="{{{$algo}}}">
 					<th>{{{++$key}}}</th>
-					<td>{{{$algo}}}</td>
-					<td>{{{$value = hash($algo, $query)}}}</td>
-					<td>{{{strtoupper($value)}}}</td>
-					<td>{{{strlen($value)}}}</td>
+					<td><samp>{{{$algo}}}</samp></td>
+					<td><samp>{{{$value = hash($algo, $query)}}}</samp></td>
+					<td><samp>{{{strtoupper($value)}}}</samp></td>
+					<td><samp>{{{strlen($value)}}}</samp></td>
 					<td>
 						@if ($algo == 'md5')
-							前16位：<br />小写：{{{substr($value, 0, 16)}}}<br />大写：{{{strtoupper(substr($value, 0, 16))}}}
+							前16位：<br />
+							小写：<samp>{{{substr($value, 0, 16)}}}</samp><br />
+							大写：<samp>{{{strtoupper(substr($value, 0, 16))}}}</samp>
 						@endif
 					</td>
 				</tr>

--- a/resources/views/encrypt/hmac.blade.php
+++ b/resources/views/encrypt/hmac.blade.php
@@ -17,7 +17,7 @@
 		<form action="{{URL::route('encrypt.hmac.post')}}" method="post">
 			<div class="form-group clearfix">
 				<label for="query" class="control-label">消息：</label>
-				{!! Form::input('text', 'query', $query, ['class' => 'form-control', 'id' => 'query']) !!}
+				<samp>{!! Form::input('text', 'query', $query, ['class' => 'form-control', 'id' => 'query']) !!}</samp>
 			</div>
 			<div class="form-group clearfix">
 				<label for="algo" class="control-label">算法：</label>
@@ -25,22 +25,22 @@
 			</div>
 			<div class="form-group clearfix">
 				<label for="key" class="control-label">秘钥：</label>
-				{!! Form::input('text', 'key', $key, ['class' => 'form-control', 'id' => 'key']) !!}
+				<samp>{!! Form::input('text', 'key', $key, ['class' => 'form-control', 'id' => 'key']) !!}</samp>
 			</div>
 			<input type="hidden" name="_token" value="{{ csrf_token() }}" />
 			<button type="submit" class="btn btn-primary">计算</button>
 			@if (isset($result))
 			<div class="form-group mt10 clearfix">
 				<label for="result" class="control-label">结果A：</label>
-				{!! Form::textarea('result', $result, ['class' => 'form-control', 'id' => 'result', 'rows' => 2, 'spellcheck' => "false"]) !!}
+				<samp>{!! Form::textarea('result', $result, ['class' => 'form-control', 'id' => 'result', 'rows' => 2, 'spellcheck' => "false"]) !!}</samp>
 			</div>
 			<div class="form-group mt10 clearfix">
 				<label for="result" class="control-label">结果A':（对上面的"结果A"进行base64编码）</label>
-				{!! Form::textarea('result', base64_encode($result), ['class' => 'form-control', 'id' => 'result_base64', 'rows' => 2, 'spellcheck' => "false"]) !!}
+				<samp>{!! Form::textarea('result', base64_encode($result), ['class' => 'form-control', 'id' => 'result_base64', 'rows' => 2, 'spellcheck' => "false"]) !!}</samp>
 			</div>
 			<div class="form-group mt10 clearfix">
 				<label for="result" class="control-label">结果B:（hmac计算返回原始二进制数据后进行base64编码）</label>
-				{!! Form::textarea('result', $rawResult, ['class' => 'form-control', 'id' => 'result_base64', 'rows' => 2, 'spellcheck' => "false"]) !!}
+				<samp>{!! Form::textarea('result', $rawResult, ['class' => 'form-control', 'id' => 'result_base64', 'rows' => 2, 'spellcheck' => "false"]) !!}</samp>
 			</div>
 			@endif
 		</form>


### PR DESCRIPTION
Changed:
- Base64 Encode/Decode
- Hash Calculator
- HMAC Calculator

Wrapped by a element call `samp` can make these code monospace. See also [Bootstrap](http://getbootstrap.com/css/#code-sample-output).